### PR TITLE
moved `set -e` after the exit_code evaluation

### DIFF
--- a/tasks/coala-checks.yaml
+++ b/tasks/coala-checks.yaml
@@ -54,8 +54,8 @@ spec:
       script: |
         set +e
         out=$(coala --ci 2>&1)
-        set -e
         exit_code=$?
+        set -e
         if [[ $exit_code -ne 0 ]]; then
           code="failure"
           description="The coala test failed!"

--- a/tasks/pr-build.yaml
+++ b/tasks/pr-build.yaml
@@ -157,8 +157,8 @@ spec:
       script: |
         set +e
         out=$(buildah images $(params.pr_repo)-$(params.pr_number):latest 2>&1)
-        set -e
         exit_code=$?
+        set -e
         if [[ $exit_code -ne 0 ]]; then
           code="failure"
           description="The image build test failed!"

--- a/tasks/pytest-checks.yaml
+++ b/tasks/pytest-checks.yaml
@@ -80,8 +80,8 @@ spec:
         if [[ -f setup.py ]]; then
           set +e
           out=$(python3 setup.py test 2>&1)
-          set -e
           exit_code=$?
+          set -e
           if [[ $exit_code -ne 0 ]]; then
             code="failure"
             description="The pytest test failed!"


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

fixes #5 

## This introduces a breaking change

- [ ] Yes
- [x] No
