### PR TITLE
Display the pipelinerun associated with tasks

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -23,6 +23,8 @@ spec:
       type: string
     - name: pr_comment_author_association
       type: string
+    - name: pipelinerun_name
+      type: string
   resources:
     - name: git-repo
       type: git
@@ -85,6 +87,8 @@ spec:
       params:
         - name: pr_number
           value: $(params.pr_number)
+        - name: pipelinerun_name
+          value: $(params.pipelinerun_name)
       resources:
         inputs:
           - name: pr
@@ -122,6 +126,8 @@ spec:
       params:
         - name: pr_number
           value: $(params.pr_number)
+        - name: pipelinerun_name
+          value: $(params.pipelinerun_name)
       resources:
         inputs:
           - name: pr
@@ -161,6 +167,8 @@ spec:
           value: $(params.pr_number)
         - name: pr_repo
           value: $(params.pr_repo)
+        - name: pipelinerun_name
+          value: $(params.pipelinerun_name)
       resources:
         inputs:
           - name: s2i-thoth

--- a/tasks/coala-checks.yaml
+++ b/tasks/coala-checks.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   params:
     - name: pr_number
-      type: string
+      description: Pull Request number.
+    - name: pipelinerun_name
+      description: pipelinerun associated.
   resources:
     inputs:
       - name: s2i-thoth
@@ -60,7 +62,7 @@ spec:
           cat <<EOF > /workspace/output/pr/status/coala.json
           {
             "State": "$code",
-            "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/",
+            "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/#/namespaces/thoth-ci/pipelineruns/$(params.pipelinerun_name)",
             "Desc": "$description",
             "Label": "thoth-ci/coala-check"
           }

--- a/tasks/pr-build.yaml
+++ b/tasks/pr-build.yaml
@@ -52,6 +52,8 @@ spec:
       description: Pull Request number.
     - name: pr_repo
       description: Pull Request repository.
+    - name: pipelinerun_name
+      description: pipelinerun associated.
   resources:
     inputs:
       - name: s2i-thoth
@@ -76,19 +78,21 @@ spec:
         git checkout workbranch
 
     - name: generate
-      command:
-        - /usr/local/bin/s2i
-        - --loglevel=$(params.LOGLEVEL)
-        - build
-        - $(params.PATH_CONTEXT)
-        - $(resources.inputs.s2i-thoth.url)
-        - --as-dockerfile
-        - /gen-source/Dockerfile.gen
       image: quay.io/openshift-pipeline/s2i:nightly
+      workingDir: /workspace/repo
+      securityContext:
+        privileged: true
+      script: |
+        if [[ -f Dockerfile ]]; then
+          cp -rf . /gen-source/
+          mv /gen-source/Dockerfile /gen-source/Dockerfile.gen
+        else
+          /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(resources.inputs.s2i-thoth.url) --as-dockerfile /gen-source/Dockerfile.gen
+        fi
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source
-      workingDir: /workspace/repo
+
 
     - name: build
       image: quay.io/buildah/stable
@@ -149,7 +153,7 @@ spec:
         cat <<EOF > /workspace/output/pr/status/build.json
         {
           "State": "$code",
-          "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/",
+          "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/#/namespaces/thoth-ci/pipelineruns/$(params.pipelinerun_name)",
           "Desc": "$description",
           "Label": "thoth-ci/build-check"
         }

--- a/tasks/pytest-checks.yaml
+++ b/tasks/pytest-checks.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   params:
     - name: pr_number
-      type: string
+      description: Pull Request number.
+    - name: pipelinerun_name
+      description: pipelinerun associated.
   resources:
     inputs:
       - name: s2i-thoth
@@ -73,7 +75,7 @@ spec:
           cat <<EOF > /workspace/output/pr/status/pytest.json
           {
             "State": "$code",
-            "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/",
+            "Target": "http://tekton-dashboard-tekton-pipelines.apps.thoth01.lab.upshift.rdu2.redhat.com/#/namespaces/thoth-ci/pipelineruns/$(params.pipelinerun_name)",
             "Desc": "$description",
             "Label": "thoth-ci/pytest-check"
           }

--- a/trigger/git-pr-template.yaml
+++ b/trigger/git-pr-template.yaml
@@ -31,12 +31,13 @@ spec:
     - name: pr_comment_author_association
       description: comment author's association.
       default: "DEFAULT"
-
+    - name: pipelinerun_name
+      description: pipelinerun associated.
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name:  pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)-$(uid)
+        name: pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)-$(uid)
         labels:
           app: thoth-ci
           component: pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)
@@ -61,6 +62,8 @@ spec:
             value: $(params.pr_comment_author)
           - name: pr_comment_author_association
             value: $(params.pr_comment_author_association)
+          - name: pipelinerun_name
+            value: pipelinerun-$(params.pr_repo)-pr-$(params.pr_number)-$(uid)
         resources:
           - name: git-repo
             resourceSpec:


### PR DESCRIPTION
Display the pipelinerun associated with tasks
Signed-off-by: harshad16 <hnalla@redhat.com>

## Related Issues and Dependencies
Fixes: #14  

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements
The pull request will enable the developer to view the pipelinerun associated with the checks.

## Description
The link are to be refined more.