### PR TITLE
:sparkles: now we also support a Containerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ thoth-ci.2020-04-14.private-key.pem
 application_default_credentials.json
 .env
 .vscode
+.lock

--- a/tasks/pr-build-release.yaml
+++ b/tasks/pr-build-release.yaml
@@ -22,13 +22,13 @@ spec:
     # s2i thoth params
     - name: ENABLE_PIPENV
       description: Set this variable to use Pipenv.
-      default: '1'
+      default: "1"
     - name: UPGRADE_PIP_TO_LATEST
       description: Set this variable to have the 'pip' program and related python packages be upgraded.
-      default: '1'
+      default: "1"
     - name: WEB_CONCURRENCY
       description: Set this to change the default setting for the number of workers.
-      default: '1'
+      default: "1"
     - name: THOTH_ADVISE
       description: Advise the recommended stack by Thoth.
       default: "0"
@@ -83,7 +83,7 @@ spec:
         - $(params.PATH_CONTEXT)
         - $(resources.inputs.s2i-thoth.url)
         - --as-dockerfile
-        - /gen-source/Dockerfile.gen
+        - /gen-source/Containerfile
       image: quay.io/openshift-pipeline/s2i:nightly
       volumeMounts:
         - mountPath: /gen-source
@@ -116,7 +116,7 @@ spec:
         - --tls-verify=$(params.TLSVERIFY)
         - --layers
         - -f
-        - /gen-source/Dockerfile.gen
+        - /gen-source/Containerfile
         - -t
         - $(params.pr_repo)-$(params.pr_number)
         - .
@@ -154,4 +154,4 @@ spec:
       emptyDir: {}
     - name: quay-creds
       secret:
-        secretName: thoth-station-thoth-pusher-secret  # Name of the secret to be parameterized
+        secretName: thoth-station-thoth-pusher-secret # Name of the secret to be parameterized

--- a/tasks/pr-build.yaml
+++ b/tasks/pr-build.yaml
@@ -19,13 +19,13 @@ spec:
     # s2i thoth params
     - name: ENABLE_PIPENV
       description: Set this variable to use Pipenv.
-      default: '1'
+      default: "1"
     - name: UPGRADE_PIP_TO_LATEST
       description: Set this variable to have the 'pip' program and related python packages be upgraded.
-      default: '1'
+      default: "1"
     - name: WEB_CONCURRENCY
       description: Set this to change the default setting for the number of workers.
-      default: '1'
+      default: "1"
     - name: THOTH_ADVISE
       description: Advise the recommended stack by Thoth.
       default: "0"
@@ -85,14 +85,16 @@ spec:
       script: |
         if [[ -f Dockerfile ]]; then
           cp -rf . /gen-source/
-          mv /gen-source/Dockerfile /gen-source/Dockerfile.gen
+          mv /gen-source/Dockerfile /gen-source/Containerfile
+        elif [[ -f Containerfile ]]; then
+          cp -rf . /gen-source/
+          mv /gen-source/Containerfile /gen-source/Containerfile
         else
-          /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(resources.inputs.s2i-thoth.url) --as-dockerfile /gen-source/Dockerfile.gen
+          /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(resources.inputs.s2i-thoth.url) --as-dockerfile /gen-source/Containerfile
         fi
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source
-
 
     - name: build
       image: quay.io/buildah/stable
@@ -120,7 +122,7 @@ spec:
         - --tls-verify=$(params.TLSVERIFY)
         - --layers
         - -f
-        - /gen-source/Dockerfile.gen
+        - /gen-source/Containerfile
         - -t
         - $(params.pr_repo)-$(params.pr_number)
         - .

--- a/tasks/tag-release-task.yaml
+++ b/tasks/tag-release-task.yaml
@@ -22,13 +22,13 @@ spec:
     # s2i thoth params
     - name: ENABLE_PIPENV
       description: Set this variable to use Pipenv.
-      default: '1'
+      default: "1"
     - name: UPGRADE_PIP_TO_LATEST
       description: Set this variable to have the 'pip' program and related python packages be upgraded.
-      default: '1'
+      default: "1"
     - name: WEB_CONCURRENCY
       description: Set this to change the default setting for the number of workers.
-      default: '1'
+      default: "1"
     - name: THOTH_ADVISE
       description: Advise the recommended stack by Thoth.
       default: "0"
@@ -82,8 +82,11 @@ spec:
         if [[ -f Dockerfile ]]; then
           cp -rf . /gen-source/
           mv /gen-source/Dockerfile /gen-source/Dockerfile.gen
+        elif [[ -f Containerfile ]]; then
+          cp -rf . /gen-source/
+          mv /gen-source/Containerfile /gen-source/Containerfile
         else
-          /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(resources.inputs.s2i-thoth.url) --as-dockerfile /gen-source/Dockerfile.gen
+          /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(resources.inputs.s2i-thoth.url) --as-dockerfile /gen-source/Containerfile
         fi
       volumeMounts:
         - mountPath: /gen-source
@@ -118,7 +121,7 @@ spec:
         - --tls-verify=$(params.TLSVERIFY)
         - --layers
         - -f
-        - /gen-source/Dockerfile.gen
+        - /gen-source/Containerfile
         - -t
         - $(params.repo_name)-$(params.git_ref)
         - .
@@ -153,4 +156,4 @@ spec:
       emptyDir: {}
     - name: quay-creds
       secret:
-        secretName: thoth-station-thoth-pusher-secret  # Name of the secret to be parameterized
+        secretName: thoth-station-thoth-pusher-secret # Name of the secret to be parameterized


### PR DESCRIPTION
now we also support a Containerfile, which is equivalent to a Dockerfile (content-wise), this is just to get rid of the "docker" word :)

Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies
n/a

## This introduces a breaking change

- [ ] Yes
- [x] No
